### PR TITLE
Dt10 hostlink patches

### DIFF
--- a/hostlink/DebugLink.cpp
+++ b/hostlink/DebugLink.cpp
@@ -159,9 +159,42 @@ DebugLink::DebugLink(DebugLinkParams p)
   }
 
   // Connect to boardctrld on each box
-  for (int y = 0; y < boxMeshYLen; y++)
-    for (int x = 0; x < boxMeshXLen; x++)
-      conn[y][x] = socketConnectTCP(boxMesh[thisBoxY+y][thisBoxX+x], 10101);
+  {
+    for (int y = 0; y < boxMeshYLen; y++){
+      for (int x = 0; x < boxMeshXLen; x++){
+        conn[y][x] = -1;
+      }
+    }
+
+    int complete=0, tries=0;
+    while(1){
+      for (int y = 0; y < boxMeshYLen; y++){
+        for (int x = 0; x < boxMeshXLen; x++){
+          if(conn[y][x]==-1){
+            conn[y][x] = socketConnectTCP(boxMesh[thisBoxY+y][thisBoxX+x], 10101, true);
+            if(conn[y][x]!=-1){
+              complete++;
+            }
+          }
+        }
+      }
+      if(complete==(boxMeshXLen*boxMeshYLen)){
+        break;
+      }
+      if(tries < p.max_connection_attempts){
+        fprintf(stderr, "Connected %u out of %u boards. Sleeping 1 second. Tries left=%u.\n", complete, (boxMeshXLen*boxMeshYLen), p.max_connection_attempts-tries );
+        tries++;
+        sleep(EXIT_FAILURE);
+      }else{
+        break;
+      }
+    }
+
+    if(complete!=(boxMeshXLen*boxMeshYLen)){
+      fprintf(stderr, "Connected %u out of %u boards. Couldnt open remaining sockets.\n", complete, (boxMeshXLen*boxMeshYLen));
+      exit(EXIT_FAILURE);
+    }
+  }
 
   // Receive ready packets from each box
   BoardCtrlPkt pkt;

--- a/hostlink/DebugLink.cpp
+++ b/hostlink/DebugLink.cpp
@@ -184,7 +184,7 @@ DebugLink::DebugLink(DebugLinkParams p)
       if(tries < p.max_connection_attempts){
         fprintf(stderr, "Connected %u out of %u boards. Sleeping 1 second. Tries left=%u.\n", complete, (boxMeshXLen*boxMeshYLen), p.max_connection_attempts-tries );
         tries++;
-        sleep(EXIT_FAILURE);
+        sleep(1);
       }else{
         break;
       }

--- a/hostlink/DebugLink.h
+++ b/hostlink/DebugLink.h
@@ -13,6 +13,10 @@ struct DebugLinkParams {
   uint32_t numBoxesX;
   uint32_t numBoxesY;
   bool useExtraSendSlot;
+
+  // Used to allow retries when connecting to the socket. When performing rapid sweeps,
+  // it is quite common for the first attempt in the next process to fail.
+  int max_connection_attempts = 5;
 };
 
 class DebugLink {

--- a/hostlink/HostLink.cpp
+++ b/hostlink/HostLink.cpp
@@ -409,7 +409,6 @@ void HostLink::boot(const char* codeFilename, const char* dataFilename)
 
   // Request to boot loader
   BootReq req;
-  static_assert(std::is_pod<BootReq>::value);
   memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
 
 
@@ -568,7 +567,6 @@ void HostLink::startAll()
 {
   // Request to boot loader
   BootReq req;
-  static_assert(std::is_pod<BootReq>::value);
   memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
 
   // Total number of cores
@@ -616,7 +614,6 @@ void HostLink::setAddr(uint32_t meshX, uint32_t meshY,
                        uint32_t coreId, uint32_t addr)
 {
   BootReq req;
-  static_assert(std::is_pod<BootReq>::value);
   memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
 
   req.cmd = SetAddrCmd;
@@ -630,7 +627,6 @@ void HostLink::store(uint32_t meshX, uint32_t meshY,
                      uint32_t coreId, uint32_t numWords, uint32_t* data)
 {
   BootReq req;
-  static_assert(std::is_pod<BootReq>::value);
   memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
 
   req.cmd = StoreCmd;
@@ -655,7 +651,6 @@ bool HostLink::powerOnSelfTest()
   // Boot request to load data from memory
   // (The test involves reading from QDRII+ SRAMs on each board)
   BootReq req;
-  static_assert(std::is_pod<BootReq>::value);
   memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
 
   req.cmd = LoadCmd;

--- a/hostlink/HostLink.cpp
+++ b/hostlink/HostLink.cpp
@@ -21,9 +21,6 @@
 #include <string.h>
 #include <signal.h>
 
-#include <type_traits>
-
-
 // Send buffer size (in flits)
 #define SEND_BUFFER_SIZE 8192
 

--- a/hostlink/HostLink.cpp
+++ b/hostlink/HostLink.cpp
@@ -98,6 +98,7 @@ void HostLink::constructor(HostLinkParams p)
   debugLinkParams.numBoxesX = p.numBoxesX;
   debugLinkParams.numBoxesY = p.numBoxesY;
   debugLinkParams.useExtraSendSlot = p.useExtraSendSlot;
+  debugLinkParams.max_connection_attempts=p.max_connection_attempts;
   debugLink = new DebugLink(debugLinkParams);
 
   // Set board mesh dimensions
@@ -136,6 +137,10 @@ void HostLink::constructor(HostLinkParams p)
   // Initialise send buffer
   useSendBuffer = false;
   sendBuffer = new char [(1<<TinselLogBytesPerFlit) * SEND_BUFFER_SIZE];
+  // avoids (correct) warnings by valgrind about passing un-init memory to syscall. In
+  // cases seen this is fine, as it is un-init padding being passed through to fill in
+  // spaces in tables for alignment purposes.
+  memset(sendBuffer, 0, (1<<TinselLogBytesPerFlit) * SEND_BUFFER_SIZE);
   sendBufferLen = 0;
 
   // Run the self test
@@ -404,6 +409,9 @@ void HostLink::boot(const char* codeFilename, const char* dataFilename)
 
   // Request to boot loader
   BootReq req;
+  static_assert(std::is_pod<BootReq>::value);
+  memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
+
 
   // Step 1: load code into instruction memory
   // -----------------------------------------
@@ -560,6 +568,8 @@ void HostLink::startAll()
 {
   // Request to boot loader
   BootReq req;
+  static_assert(std::is_pod<BootReq>::value);
+  memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
 
   // Total number of cores
   const uint32_t numCores =
@@ -606,6 +616,9 @@ void HostLink::setAddr(uint32_t meshX, uint32_t meshY,
                        uint32_t coreId, uint32_t addr)
 {
   BootReq req;
+  static_assert(std::is_pod<BootReq>::value);
+  memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
+
   req.cmd = SetAddrCmd;
   req.numArgs = 1;
   req.args[0] = addr;
@@ -617,6 +630,9 @@ void HostLink::store(uint32_t meshX, uint32_t meshY,
                      uint32_t coreId, uint32_t numWords, uint32_t* data)
 {
   BootReq req;
+  static_assert(std::is_pod<BootReq>::value);
+  memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
+
   req.cmd = StoreCmd;
   while (numWords > 0) {
     uint32_t sendWords = numWords > 15 ? 15 : numWords;
@@ -639,6 +655,9 @@ bool HostLink::powerOnSelfTest()
   // Boot request to load data from memory
   // (The test involves reading from QDRII+ SRAMs on each board)
   BootReq req;
+  static_assert(std::is_pod<BootReq>::value);
+  memset(&req, 0, sizeof(BootReq)); // Keep valgrind happy about un-init bytes.
+
   req.cmd = LoadCmd;
   req.numArgs = 1;
   req.args[0] = 1;
@@ -743,7 +762,10 @@ void HostLink::dumpStdOut(FILE* outFile)
 {
   for (;;) {
     bool ok = pollStdOut(outFile);
-    if (!ok) usleep(10000);
+    if (!ok){
+      fflush(outFile); // Try to ensure output becomes visible to sink process
+      usleep(10000);
+    }
   }
 }
 
@@ -753,7 +775,10 @@ void HostLink::dumpStdOut(FILE* outFile, uint32_t lines)
   uint32_t count = 0;
   while (count < lines) {
     bool ok = pollStdOut(outFile, &count);
-    if (!ok) usleep(10000);
+    if (!ok){
+      fflush(outFile); // Try to ensure output becomes visible to sink process
+      usleep(10000);
+    }
   }
 }
 

--- a/hostlink/HostLink.h
+++ b/hostlink/HostLink.h
@@ -21,6 +21,10 @@ struct HostLinkParams {
   uint32_t numBoxesX;
   uint32_t numBoxesY;
   bool useExtraSendSlot;
+
+  // Used to allow retries when connecting to the socket. When performing rapid sweeps,
+  // it is quite common for the first attempt in the next process to fail.
+  int max_connection_attempts = 5;
 };
 
 class HostLink {

--- a/hostlink/SocketUtils.cpp
+++ b/hostlink/SocketUtils.cpp
@@ -95,7 +95,7 @@ int socketPut(int fd, char* buf, int numBytes)
 }
 
 // Create TCP connection to given host/port
-int socketConnectTCP(const char* hostname, int port)
+int socketConnectTCP(const char* hostname, int port, bool returnCantConnect)
 {
   // Resolve hostname
   hostent* hostInfo = gethostbyname2(hostname, AF_INET);
@@ -122,7 +122,11 @@ int socketConnectTCP(const char* hostname, int port)
     fprintf(stderr, "Can't connect to host '%s' on port '%d'\n",
       hostname, port);
     fprintf(stderr, "Box '%s' already in use?\n", hostname);
-    exit(EXIT_FAILURE);
+    if(returnCantConnect){
+      return -1;
+    }else{
+      exit(EXIT_FAILURE);
+    }
   }
 
   return sock;

--- a/hostlink/SocketUtils.h
+++ b/hostlink/SocketUtils.h
@@ -30,6 +30,10 @@ void socketBlockingGet(int fd, char* buf, int numBytes);
 void socketBlockingPut(int fd, char* buf, int numBytes);
 
 // Create TCP connection to given host/port
-int socketConnectTCP(const char* hostname, int port);
+/*!
+    \param returnIfCantConnect In the case that we cant connect, return -1 rather than exit
+*/
+int socketConnectTCP(const char* hostname, int port, bool returnIfCantConnect=false);
+
 
 #endif


### PR DESCRIPTION
Adds the ability to retry connections to boxes, as occasionally TCP connections will
fail when rapidly opening and closing hostlink in multiple programs in  sequence.

Explicit memsets are to avoid uninitialised memory (last few bytes of BootReq)
getting sent. It is benign in this scenario, but valgrind doesn't know this.

Flushes on stdout are for cases where you are sending thread output to stdout
and into another process (e.g. piping it through grep or something). Forcing
the flush when there is no more data avoids the situation where the string you
are looking for has been read, but not yet sent. In principle the fflush could lower
performance, but it is followed by a 10ms wait, so seems fairly safe.

Tested on ayres and byron (2x2 boxes), though only by building and then running "hello".