### PR TITLE
dt10 build patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 # SPDX-License-Identifier: BSD-2-Clause
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
 
 .PHONY: nothing
 nothing:

--- a/apps/POLite/util/polite.mk
+++ b/apps/POLite/util/polite.mk
@@ -3,10 +3,6 @@
 # Tinsel root
 TINSEL_ROOT ?= ../../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # Local compiler flags

--- a/apps/POLite/util/polite.mk
+++ b/apps/POLite/util/polite.mk
@@ -43,15 +43,15 @@ $(BUILD)/link.ld: builddir $(TINSEL_ROOT)/apps/POLite/util/genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a:
+	make -C $(HL) hostlink.a
 
-$(BUILD)/run: $(RUN_CPP) $(RUN_H) $(HL)/*.o
-	g++ -std=c++11 -O2 -I $(INC) -I $(HL) -o $(BUILD)/run $(RUN_CPP) $(HL)/*.o \
+$(BUILD)/run: $(RUN_CPP) $(RUN_H) $(HL)/hostlink.a
+	g++ -std=c++11 -O2 -I $(INC) -I $(HL) -o $(BUILD)/run $(RUN_CPP) $(HL)/hostlink.a \
 	  -lmetis -fno-exceptions -fopenmp
 
-$(BUILD)/sim: $(RUN_CPP) $(RUN_H) $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o $(BUILD)/sim $(RUN_CPP) $(HL)/sim/*.o \
+$(BUILD)/sim: $(RUN_CPP) $(RUN_H) $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o $(BUILD)/sim $(RUN_CPP) $(HL)/sim/hostlink.a \
     -lmetis
 
 .PHONY: clean

--- a/apps/custom/Makefile
+++ b/apps/custom/Makefile
@@ -2,10 +2,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # RISC-V compiler flags

--- a/apps/custom/Makefile
+++ b/apps/custom/Makefile
@@ -32,14 +32,17 @@ link.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/heat/Makefile
+++ b/apps/heat/Makefile
@@ -32,14 +32,14 @@ link.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a:
+	make -C $(HL) hostlink.a
 
-run: run.cpp heat.h $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp heat.h $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp heat.h $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+sim: run.cpp heat.h $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/hello/Makefile
+++ b/apps/hello/Makefile
@@ -2,10 +2,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # Local compiler flags

--- a/apps/hello/Makefile
+++ b/apps/hello/Makefile
@@ -35,14 +35,17 @@ link.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/linkrate/Makefile
+++ b/apps/linkrate/Makefile
@@ -2,10 +2,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # RISC-V compiler flags

--- a/apps/linkrate/Makefile
+++ b/apps/linkrate/Makefile
@@ -36,14 +36,17 @@ link.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/multiprog/Makefile
+++ b/apps/multiprog/Makefile
@@ -35,14 +35,17 @@ link_1.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/multiprog/Makefile
+++ b/apps/multiprog/Makefile
@@ -2,10 +2,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # RISC-V compiler flags

--- a/apps/ping/Makefile
+++ b/apps/ping/Makefile
@@ -1,10 +1,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # RISC-V compiler flags

--- a/apps/ping/Makefile
+++ b/apps/ping/Makefile
@@ -31,14 +31,17 @@ link.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/ring/Makefile
+++ b/apps/ring/Makefile
@@ -2,10 +2,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # RISC-V compiler flags

--- a/apps/ring/Makefile
+++ b/apps/ring/Makefile
@@ -32,14 +32,17 @@ link.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/sync/Makefile
+++ b/apps/sync/Makefile
@@ -2,10 +2,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # RISC-V compiler flags

--- a/apps/sync/Makefile
+++ b/apps/sync/Makefile
@@ -32,14 +32,17 @@ link.ld: genld.sh
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/apps/temps/Makefile
+++ b/apps/temps/Makefile
@@ -2,10 +2,6 @@
 # Tinsel root
 TINSEL_ROOT=../..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 .PHONY: all

--- a/apps/temps/Makefile
+++ b/apps/temps/Makefile
@@ -10,14 +10,17 @@ all: run
 $(INC)/config.h: $(TINSEL_ROOT)/config.py
 	make -C $(INC)
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:

--- a/de5/Makefile
+++ b/de5/Makefile
@@ -1,10 +1,6 @@
 TINSEL_ROOT = ..
 include $(TINSEL_ROOT)/globals.mk
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 .PHONY: all
 all: 
 	make -C $(TINSEL_ROOT)/rtl verilog

--- a/de5/bridge-board/Makefile
+++ b/de5/bridge-board/Makefile
@@ -1,10 +1,6 @@
 TINSEL_ROOT = ../..
 include $(TINSEL_ROOT)/globals.mk
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 .PHONY: all
 all: 
 	make -C $(TINSEL_ROOT)/rtl verilog

--- a/hostlink/Makefile
+++ b/hostlink/Makefile
@@ -16,13 +16,13 @@ all: DebugLink.o HostLink.o MemFileReader.o jtag/UART.o pciestreamd \
 	 hostlink.a
 
 hostlink.a : DebugLink.o HostLink.o MemFileReader.o SocketUtils.o
-	-rm -f $@
-	ar rcu $@ $^
+	[ ! -f $@ ] || rm $@
+	ar rc $@ $^
 	ranlib $@
 
 sim/hostlink.a : sim/DebugLink.o sim/HostLink.o sim/MemFileReader.o sim/SocketUtils.o
-	-rm -f $@
-	ar rcu $@ $^
+	[ ! -f $@ ] || rm $@
+	ar rc $@ $^
 	ranlib $@
 
 pciestreamd: pciestreamd.cpp 

--- a/hostlink/Makefile
+++ b/hostlink/Makefile
@@ -12,7 +12,18 @@ HL = $(TINSEL_ROOT)/hostlink
 all: DebugLink.o HostLink.o MemFileReader.o jtag/UART.o pciestreamd \
      sim/DebugLink.o sim/HostLink.o sim/MemFileReader.o sim/UART.o \
      SocketUtils.o sim/SocketUtils.o udsock boardctrld \
-     sim/boardctrld fancheck
+     sim/boardctrld fancheck \
+	 hostlink.a
+
+hostlink.a : DebugLink.o HostLink.o MemFileReader.o SocketUtils.o
+	-rm $@
+	ar rcu $@ $^
+	ranlib $@
+
+sim/hostlink.a : sim/DebugLink.o sim/HostLink.o sim/MemFileReader.o sim/SocketUtils.o
+	-rm $@
+	ar rcu $@ $^
+	ranlib $@
 
 pciestreamd: pciestreamd.cpp 
 	g++ -Wall -I $(HL) -O2 pciestreamd.cpp -o pciestreamd
@@ -62,5 +73,5 @@ $(INC)/config.h: $(TINSEL_ROOT)/config.py
 
 .PHONY: clean
 clean:
-	rm -f *.o pciestreamd udsock boardctrld fancheck jtag/*.o
+	rm -f *.o pciestreamd udsock boardctrld fancheck jtag/*.o hostlink.a
 	rm -rf sim

--- a/hostlink/Makefile
+++ b/hostlink/Makefile
@@ -2,10 +2,6 @@
 TINSEL_ROOT = ..
 include $(TINSEL_ROOT)/globals.mk
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 # Local compiler flags
 CPPFLAGS = -I$(INC) -O2 -Wall
 
@@ -24,6 +20,7 @@ pciestreamd: pciestreamd.cpp
 boardctrld: boardctrld.cpp PowerLink.o JtagAtlantic.h \
             $(INC)/config.h jtag/UART.h Queue.h jtag/UARTBuffer.h \
             jtag/UART.o SocketUtils.o DebugLinkFormat.h BoardCtrl.h
+		[ "$(QUARTUS_ROOTDIR)" != "" ] || { echo "Please set QUARTUS_ROOTDIR to compile boardctrld" ; exit 1 ; } ; \
 	g++ -std=c++98 boardctrld.cpp jtag/UART.o PowerLink.o SocketUtils.o \
 	  $(CPPFLAGS) -I $(HL) -o boardctrld \
 	  -ljtag_atlantic -ljtag_client -L $(QUARTUS_ROOTDIR)/linux64/ \

--- a/hostlink/Makefile
+++ b/hostlink/Makefile
@@ -16,12 +16,12 @@ all: DebugLink.o HostLink.o MemFileReader.o jtag/UART.o pciestreamd \
 	 hostlink.a
 
 hostlink.a : DebugLink.o HostLink.o MemFileReader.o SocketUtils.o
-	-rm $@
+	-rm -f $@
 	ar rcu $@ $^
 	ranlib $@
 
 sim/hostlink.a : sim/DebugLink.o sim/HostLink.o sim/MemFileReader.o sim/SocketUtils.o
-	-rm $@
+	-rm -f $@
 	ar rcu $@ $^
 	ranlib $@
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 TINSEL_ROOT = ..
 
-ifndef QUARTUS_ROOTDIR
-  $(error Please set QUARTUS_ROOTDIR)
-endif
-
 include $(TINSEL_ROOT)/globals.mk
 
 # Local compiler flags

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,14 +27,17 @@ all: $(patsubst %.S,%.code.v,$(wildcard *.S)) \
 link.ld: genld.sh
 	./genld.sh > link.ld
 
-$(HL)/%.o:
-	make -C $(HL)
+$(HL)/hostlink.a :
+	make -C $(HL) hostlink.a
 
-run: run.cpp $(HL)/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/*.o
+run: run.cpp $(HL)/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o run run.cpp $(HL)/hostlink.a
 
-sim: run.cpp $(HL)/sim/*.o
-	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/*.o
+$(HL)/sim/hostlink.a :
+	make -C $(HL) sim/hostlink.a
+
+sim: run.cpp $(HL)/sim/hostlink.a
+	g++ -O2 -I $(INC) -I $(HL) -o sim run.cpp $(HL)/sim/hostlink.a
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This changes two things related to building:

- When building user apps it removes the dependency on QUARTUS_ROOTDIR, which makes it easier
  to build and test things locally. Since the split into having a deamon the only thing with a true
  dependency is boardtrld, which now has a build-time check for the environment variable:

  https://github.com/POETSII/tinsel/blob/6bec443edf87f0fb43cba3c0e86f914910260d18/hostlink/Makefile#L34

- packages the hostlink user code into a library hostlink.a, rather than linking objects by wildcard

