### PR TITLE
Extend appendix about address structure and boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1502,7 +1502,7 @@ LSB.
 A globally unique mailbox id is exactly the same, except it is missing
 the mailbox-local thread id component.
 
-So a thread address is an integer in the half-open range `[0..2**(MeshYBits+MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))`,
+So a thread address is an integer in the half-open range `[0..2^(MeshYBits+MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))`,
 with the following structure:
 ```
             +-- LSB (bit 0)
@@ -1525,16 +1525,16 @@ accelerators, bridge boards, and programmable routers.  Details of
 these can be found in the `MailboxNetAddr`
 [structure](rtl/Globals.bsv).
 
-### Example structure for Tinsel 0.8.3
+### Example structure for Tinsel 0.8
 
 You must always rely on the configured parameters for the system you are using, but as an
-example for the Tinsel 0.8.3 release, these parameters are:
+example for the Tinsel 0.8 release, these parameters are:
 
-- MeshYBits = 3
-- MeshXBits = 3
-- MailboxMeshYBits = 2
-- MailboxMeshXBits = 2
-- LogThreadsPerMailbox = LogCoresPerMailbox + LogThreadsPerCore = 2 + 4 = 6
+- `MeshYBits = 3`
+- `MeshXBits = 3`
+- `MailboxMeshYBits = 2`
+- `MailboxMeshXBits = 2`
+- `LogThreadsPerMailbox = LogCoresPerMailbox+LogThreadsPerCore = 2+4 = 6`
 
 _So with these specific parameters_, this leads to a 16 bit thread address in Tinsel 0.8:
 ```
@@ -1556,24 +1556,24 @@ as it is determined by compile-time and run-time parameters:
 
 1. (`BoxMeshXLen`,`BoxMeshYLen`) : how many physical boxes exist in the system at compile-time, given in the local `config.h`; and
 2. (`numBoxesX`,`numBoxesY`) : how many boxes have been requested at run-time when initialising hostlink, where
-   `numBoxesX <= BoxMeshXLen` and `numBoxesY <= boxMeshYLen`.
+   `numBoxesX` <= `BoxMeshXLen` and `numBoxesY` <= `boxMeshYLen`.
 
 Given the run-time values `numBoxesX` and `numBoxes`, we have the following ranges for X and Y:
 
-- `0 <= Y < numBoxesX * MeshXLenWithinBox`
-- `0 <= X < numBoxesY * MeshYLenWithinBox`
+- `0 <= YYY < numBoxesX * MeshXLenWithinBox`
+- `0 <= XXX < numBoxesY * MeshYLenWithinBox`
 
 So this means that:
 
-- If `numBoxesX < 2**MeshXBits` then not all X values will be valid, so there will be "gaps" in
+- If `numBoxesX < 2^MeshXBits` then not all `XXX` values will be valid, so there will be "gaps" in
   the thread addresses range that do not correspond to any valid FPGA or thread.
   
-- If `numBoxesX == 2**MeshXBits` then the thread addresses forms a single unbroken contiguous range, so
-  every value in the range `[0,numBoxesY * 2**(MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox) )`
+- If `numBoxesX == 2^MeshXBits` then the thread addresses forms a single unbroken contiguous range, so
+  every value in the range `[0,numBoxesY * 2^(MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))`
   is a valid address.
   
 - If `numBoxesX == 2**MeshXBits` and `numBoxesY == 2**MeshYBits` then every bit pattern
-  with length `(MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox)`
+  with length `(MeshYBits+MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox)`
   is a valid address.
 
 ## F. Tinsel API

--- a/README.md
+++ b/README.md
@@ -1502,7 +1502,7 @@ LSB.
 A globally unique mailbox id is exactly the same, except it is missing
 the mailbox-local thread id component.
 
-So the address is an integer in the range `[0..2**MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox)`,
+So a thread address is an integer in the half-open range `[0..2**(MeshYBits+MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))`,
 with the following structure:
 ```
             +-- LSB (bit 0)
@@ -1519,10 +1519,16 @@ code can be performed using `tinselToAddr` and `tinselFromAddr` in [tinsel-inter
 These functions automatically take into account the configured parameters, and should be preferred
 to direct manipulation of addresses in most circumstances.
 
-### Example structure for Tinsel 0.8
+Note that there are a few additional most-significant bits that are
+used to address hardware components that are not threads, e.g. custom
+accelerators, bridge boards, and programmable routers.  Details of
+these can be found in the `MailboxNetAddr`
+[structure](rtl/Globals.bsv).
+
+### Example structure for Tinsel 0.8.3
 
 You must always rely on the configured parameters for the system you are using, but as an
-example for the Tinsel 0.8 release, these parameters are:
+example for the Tinsel 0.8.3 release, these parameters are:
 
 - MeshYBits = 3
 - MeshXBits = 3

--- a/README.md
+++ b/README.md
@@ -1559,7 +1559,8 @@ as it is determined by compile-time and run-time parameters:
 2. (`numBoxesX`,`numBoxesY`) : how many boxes have been requested at run-time when initialising hostlink, where
    `numBoxesX` <= `BoxMeshXLen` and `numBoxesY` <= `boxMeshYLen`.
 
-Given the run-time values `numBoxesX` and `numBoxes`, we have the following ranges for X and Y:
+Given the run-time values `numBoxesX` and `numBoxesY`, we have the
+following ranges for `XXX` and `YYY`:
 
 - 0 <= `YYY` < `numBoxesX` * `MeshXLenWithinBox`
 - 0 <= `XXX` < `numBoxesY` * `MeshYLenWithinBox`

--- a/README.md
+++ b/README.md
@@ -1503,7 +1503,7 @@ A globally unique mailbox id is exactly the same, except it is missing
 the mailbox-local thread id component.
 
 So a thread address is an integer in the half-open range
-[0..2^(`MeshYBits`+`MeshXBits`+`MailboxMeshYBits`+`MailboxMeshXBits`+`LogThreadsPerMailbox`)),
+[0 .. 2^(`MeshYBits` + `MeshXBits` + `MailboxMeshYBits` + `MailboxMeshXBits` + `LogThreadsPerMailbox`)),
 with the following structure:
 ```
             +-- LSB (bit 0)
@@ -1535,7 +1535,7 @@ example for the Tinsel 0.8 release, these parameters are:
 - `MeshXBits` = 3
 - `MailboxMeshYBits` = 2
 - `MailboxMeshXBits` = 2
-- `LogThreadsPerMailbox` = `LogCoresPerMailbox`+`LogThreadsPerCore` = 2+4 = 6
+- `LogThreadsPerMailbox` = `LogCoresPerMailbox` + `LogThreadsPerCore` = 2+4 = 6
 
 _So with these specific parameters_, this leads to a 16 bit thread address in Tinsel 0.8:
 ```
@@ -1568,9 +1568,12 @@ So this means that:
 
 - If `numBoxesX` < 2^`MeshXBits` then not all `XXX` values will be valid, so there will be "gaps" in the thread addresses range that do not correspond to any valid FPGA or thread.
   
-- If `numBoxesX` = 2^`MeshXBits` then the thread addresses forms a single unbroken contiguous range, so every value in the range `[0,numBoxesY * 2^(MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))` is a valid address.
+- If `numBoxesX` = 2^`MeshXBits` then the thread addresses forms a
+  single unbroken contiguous range, so every value in the range
+[0, `numBoxesY` * 2^(`MeshXBits` + `MailboxMeshYBits` +
+`MailboxMeshXBits` + `LogThreadsPerMailbox`)) is a valid address.
   
-- If `numBoxesX` = 2^`MeshXBits` and `numBoxesY` = 2^`MeshYBits` then every bit pattern with length (`MeshYBits`+`MeshXBits`+`MailboxMeshYBits`+`MailboxMeshXBits`+`LogThreadsPerMailbox`) is a valid address.
+- If `numBoxesX` = 2^`MeshXBits` and `numBoxesY` = 2^`MeshYBits` then every bit pattern with length (`MeshYBits` + `MeshXBits` + `MailboxMeshYBits` + `MailboxMeshXBits` + `LogThreadsPerMailbox`) is a valid address.
 
 ## F. Tinsel API
 

--- a/README.md
+++ b/README.md
@@ -1502,7 +1502,8 @@ LSB.
 A globally unique mailbox id is exactly the same, except it is missing
 the mailbox-local thread id component.
 
-So a thread address is an integer in the half-open range `[0..2^(MeshYBits+MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))`,
+So a thread address is an integer in the half-open range
+[0..2^(`MeshYBits`+`MeshXBits`+`MailboxMeshYBits`+`MailboxMeshXBits`+`LogThreadsPerMailbox`)),
 with the following structure:
 ```
             +-- LSB (bit 0)
@@ -1530,11 +1531,11 @@ these can be found in the `MailboxNetAddr`
 You must always rely on the configured parameters for the system you are using, but as an
 example for the Tinsel 0.8 release, these parameters are:
 
-- `MeshYBits = 3`
-- `MeshXBits = 3`
-- `MailboxMeshYBits = 2`
-- `MailboxMeshXBits = 2`
-- `LogThreadsPerMailbox = LogCoresPerMailbox+LogThreadsPerCore = 2+4 = 6`
+- `MeshYBits` = 3
+- `MeshXBits` = 3
+- `MailboxMeshYBits` = 2
+- `MailboxMeshXBits` = 2
+- `LogThreadsPerMailbox` = `LogCoresPerMailbox`+`LogThreadsPerCore` = 2+4 = 6
 
 _So with these specific parameters_, this leads to a 16 bit thread address in Tinsel 0.8:
 ```
@@ -1560,21 +1561,16 @@ as it is determined by compile-time and run-time parameters:
 
 Given the run-time values `numBoxesX` and `numBoxes`, we have the following ranges for X and Y:
 
-- `0 <= YYY < numBoxesX * MeshXLenWithinBox`
-- `0 <= XXX < numBoxesY * MeshYLenWithinBox`
+- 0 <= `YYY` < `numBoxesX` * `MeshXLenWithinBox`
+- 0 <= `XXX` < `numBoxesY` * `MeshYLenWithinBox`
 
 So this means that:
 
-- If `numBoxesX < 2^MeshXBits` then not all `XXX` values will be valid, so there will be "gaps" in
-  the thread addresses range that do not correspond to any valid FPGA or thread.
+- If `numBoxesX` < 2^`MeshXBits` then not all `XXX` values will be valid, so there will be "gaps" in the thread addresses range that do not correspond to any valid FPGA or thread.
   
-- If `numBoxesX == 2^MeshXBits` then the thread addresses forms a single unbroken contiguous range, so
-  every value in the range `[0,numBoxesY * 2^(MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))`
-  is a valid address.
+- If `numBoxesX` = 2^`MeshXBits` then the thread addresses forms a single unbroken contiguous range, so every value in the range `[0,numBoxesY * 2^(MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox))` is a valid address.
   
-- If `numBoxesX == 2**MeshXBits` and `numBoxesY == 2**MeshYBits` then every bit pattern
-  with length `(MeshYBits+MeshXBits+MailboxMeshYBits+MailboxMeshXBits+LogThreadsPerMailbox)`
-  is a valid address.
+- If `numBoxesX` = 2^`MeshXBits` and `numBoxesY` = 2^`MeshYBits` then every bit pattern with length (`MeshYBits`+`MeshXBits`+`MailboxMeshYBits`+`MailboxMeshXBits`+`LogThreadsPerMailbox`) is a valid address.
 
 ## F. Tinsel API
 


### PR DESCRIPTION
Added some more details about how addresses map onto bit patterns,
and how that relates to the box layout at compile-time and run-time.

I've needed to work this out a few times when trying to play around with
generating random addresses, so tried to capture it - at least as I understand it.

The example for tinsel-0.8 might be a bit problematic if people read it and
think "addresses are always 16-bit", but it's also quite useful to see example
parameters. Particularly if I've got them wrong.