### PR TITLE
Support boot in hostlink without starting the cores.

### DIFF
--- a/hostlink/HostLink.cpp
+++ b/hostlink/HostLink.cpp
@@ -475,7 +475,7 @@ void HostLink::loadAll(const char* codeFilename, const char* dataFilename)
 void HostLink::boot(const char* codeFilename, const char* dataFilename)
 {
     loadAll(codeFilename, dataFilename);
-    start();
+    startAll();
 }
 
 // Trigger to start application execution

--- a/hostlink/HostLink.cpp
+++ b/hostlink/HostLink.cpp
@@ -402,7 +402,8 @@ bool HostLink::canRecv()
 }
 
 // Load application code and data onto the mesh
-void HostLink::boot(const char* codeFilename, const char* dataFilename)
+void HostLink::boot(const char* codeFilename, const char* dataFilename,
+                    bool start)
 {
   MemFileReader code(codeFilename);
   MemFileReader data(dataFilename);
@@ -473,8 +474,8 @@ void HostLink::boot(const char* codeFilename, const char* dataFilename)
   // Step 3: start cores
   // -------------------
 
-  // Send start command
-  startAll();
+  // Send start command, if desired
+  if (start) startAll();
 }
 
 // Trigger to start application execution

--- a/hostlink/HostLink.cpp
+++ b/hostlink/HostLink.cpp
@@ -402,8 +402,7 @@ bool HostLink::canRecv()
 }
 
 // Load application code and data onto the mesh
-void HostLink::boot(const char* codeFilename, const char* dataFilename,
-                    bool start)
+void HostLink::loadAll(const char* codeFilename, const char* dataFilename)
 {
   MemFileReader code(codeFilename);
   MemFileReader data(dataFilename);
@@ -470,12 +469,13 @@ void HostLink::boot(const char* codeFilename, const char* dataFilename,
     }
     addrReg = addr + 4;
   }
+}
 
-  // Step 3: start cores
-  // -------------------
-
-  // Send start command, if desired
-  if (start) startAll();
+// Load application code and data onto the mesh, and start the cores
+void HostLink::boot(const char* codeFilename, const char* dataFilename)
+{
+    loadAll(codeFilename, dataFilename);
+    start();
 }
 
 // Trigger to start application execution

--- a/hostlink/HostLink.h
+++ b/hostlink/HostLink.h
@@ -133,7 +133,8 @@ class HostLink {
   // (Only thread 0 on each core is active when the boot loader is running)
 
   // Load application code and data onto the mesh
-  void boot(const char* codeFilename, const char* dataFilename);
+  void boot(const char* codeFilename, const char* dataFilename,
+            bool start=true);
 
   // Trigger to start application execution
   void go();

--- a/hostlink/HostLink.h
+++ b/hostlink/HostLink.h
@@ -133,8 +133,10 @@ class HostLink {
   // (Only thread 0 on each core is active when the boot loader is running)
 
   // Load application code and data onto the mesh
-  void boot(const char* codeFilename, const char* dataFilename,
-            bool start=true);
+  void loadAll(const char* codeFilename, const char* dataFilename);
+
+  // ... and start
+  void boot(const char* codeFilename, const char* dataFilename);
 
   // Trigger to start application execution
   void go();


### PR DESCRIPTION
Needed to support efficient loading of cores (without reading the same file multiple times), in order to support hardware idle detection by the Orchestrator (see also https://github.com/poetsii/orchestrator/issues/242).