### PR TITLE
Initialise fields in 'Params' structures using a constructor.

### DIFF
--- a/hostlink/DebugLink.h
+++ b/hostlink/DebugLink.h
@@ -16,7 +16,8 @@ struct DebugLinkParams {
 
   // Used to allow retries when connecting to the socket. When performing rapid sweeps,
   // it is quite common for the first attempt in the next process to fail.
-  int max_connection_attempts = 5;
+  int max_connection_attempts;
+  DebugLinkParams(): max_connection_attempts(5){}
 };
 
 class DebugLink {

--- a/hostlink/HostLink.h
+++ b/hostlink/HostLink.h
@@ -24,7 +24,8 @@ struct HostLinkParams {
 
   // Used to allow retries when connecting to the socket. When performing rapid sweeps,
   // it is quite common for the first attempt in the next process to fail.
-  int max_connection_attempts = 5;
+  int max_connection_attempts;
+  HostLinkParams(): max_connection_attempts(5){}
 };
 
 class HostLink {


### PR DESCRIPTION
Just a small fix to improve C++98 compatibility.

I've compiled this, but I haven't run it on anything (I don't believe I have the means to do so), so this needs some subjecting to your CI before merging I think.

Also linking @heliosfa, as he found it.